### PR TITLE
Fix fifo reading if named pipe remains open

### DIFF
--- a/fifo.go
+++ b/fifo.go
@@ -37,38 +37,49 @@ func NewFifoHandler(cfg notifyConfig, pipe io.Reader, events <-chan fsnotify.Eve
 }
 
 func (h FifoHandler) HandleFifo(ctx context.Context) error {
-
+	err := h.handleFifoEvents(ctx)
+	if err != nil {
+		logrus.Errorf("Failed to read from named pipe: %s", err)
+	}
 	for {
 		select {
 		case e := <-h.events:
+			logrus.Debugf("got event: %q", e.Op.String())
 			switch e.Op {
 			case fsnotify.Write:
-				s := bufio.NewScanner(h.pipe)
-				for s.Scan() {
-					line := s.Text()
-					logrus.Infof("Got line: %q", s.Text())
-					n, err := parseNotificationLine(line)
-					if err != nil {
-						logrus.Errorf("Failed to parse fifo event from keepalived, keepalived might be incompatible with the floaty version: %s", err)
-						continue
-					}
-					err = h.handleNotifyEvent(ctx, n)
-					if err != nil {
-						logrus.Errorf("Failed to handle notify event: %s", err)
-						continue
-					}
-					logrus.Infof("handled: %q", s.Text())
+				err := h.handleFifoEvents(ctx)
+				if err != nil {
+					logrus.Errorf("Failed to read from named pipe: %s", err)
 				}
-
 			case fsnotify.Remove, fsnotify.Rename:
 				return fmt.Errorf("Named pipe was removed. Quitting")
 			}
 		case <-ctx.Done():
 			return nil
 		}
-		logrus.Infof("event done")
 	}
 }
+
+func (h FifoHandler) handleFifoEvents(ctx context.Context) error {
+	s := bufio.NewScanner(h.pipe)
+	for s.Scan() {
+		line := s.Text()
+		logrus.Debugf("Got line: %q", s.Text())
+		n, err := parseNotificationLine(line)
+		if err != nil {
+			logrus.Errorf("Failed to parse fifo event from keepalived, keepalived might be incompatible with the floaty version: %s", err)
+			continue
+		}
+		err = h.handleNotifyEvent(ctx, n)
+		if err != nil {
+			logrus.Errorf("Failed to handle notify event: %s", err)
+			continue
+		}
+	}
+	// Only returns non EOF errors
+	return s.Err()
+}
+
 func (h FifoHandler) handleNotifyEvent(ctx context.Context, n Notification) error {
 	stopRunning, ok := h.running[n.Instance]
 	if ok {

--- a/main.go
+++ b/main.go
@@ -143,7 +143,13 @@ func runFifo(ctx context.Context, cfg notifyConfig) error {
 	if err != nil {
 		return fmt.Errorf("Failed to setup FIFO handler: %w", err)
 	}
-	return fifoHandler.HandleFifo(ctx)
+	ctx, done := context.WithCancel(ctx)
+	go func() {
+		err = fifoHandler.HandleFifo(ctx)
+		done()
+	}()
+	<-ctx.Done()
+	return err
 }
 
 func runNotify(ctx context.Context, cfg notifyConfig) error {

--- a/notification.go
+++ b/notification.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/csv"
 	"errors"
 	"fmt"
 	"strings"
@@ -22,6 +23,22 @@ const (
 	NotificationFault  NotificationStatus = "FAULT"
 	NotificationBackup NotificationStatus = "BACKUP"
 )
+
+func parseNotificationLine(line string) (Notification, error) {
+	// Yes, this can actually be parsed as a CSV file with spaces as separators and it handles quoted string the same way a shell does.
+	r := csv.NewReader(strings.NewReader(line))
+	r.Comma = ' '
+	notifications, err := r.ReadAll()
+	if err != nil {
+		return Notification{}, err
+	}
+
+	if len(notifications) != 1 {
+		return Notification{}, fmt.Errorf("Failed to parse notification: %q", line)
+	}
+
+	return parseNotification(notifications[0])
+}
 
 func parseNotification(fields []string) (Notification, error) {
 	line := strings.Join(fields, " ")


### PR DESCRIPTION
## Summary
Keepalived FIFO did not quite work as expected. This update will correctly work even if the sending pipe never sends an EOF


## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
