### PR TITLE
Add separate steps in GitHub action for snapshots and release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,13 @@ jobs:
         outputFile: .github/release-notes.md
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Publish releases
+    - name: Build snapshot for master
+      if: "!startsWith(github.ref, 'refs/tags/v')"
+      uses: goreleaser/goreleaser-action@v4
+      with:
+        args: build --snapshot
+    - name: Build and publish release for tag
+      if: startsWith(github.ref, 'refs/tags/v')
       uses: goreleaser/goreleaser-action@v4
       with:
         args: release --release-notes .github/release-notes.md


### PR DESCRIPTION
## Summary

The goreleaser v4 GitHub action has completely removed support for automatically doing snapshot builds for commits which aren't associated with a tag. Since goreleaser's `--snapshot` doesn't have any smarts to do a non-snapshot build for commits which are tagged, we split the goreleaser step into separate steps for actions running against a tag and actions running against master.

Follow-up to #58

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
