### PR TITLE
Use goreleaser's `--auto-snapshot` feature for master builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,16 +47,11 @@ jobs:
         outputFile: .github/release-notes.md
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build snapshot for master
-      if: "!startsWith(github.ref, 'refs/tags/v')"
-      uses: goreleaser/goreleaser-action@v4
-      with:
-        args: build --snapshot
-    - name: Build and publish release for tag
+    - name: Publish releases
       if: startsWith(github.ref, 'refs/tags/v')
       uses: goreleaser/goreleaser-action@v4
       with:
-        args: release --release-notes .github/release-notes.md
+        args: release --auto-snapshot --release-notes .github/release-notes.md
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name:  Upload deb


### PR DESCRIPTION
## Summary

Despite my claim in #59, goreleaser does have logic to automatically enable snapshots for dirty commits. This commit reverts most of the changes from #59 and instead enables goreleaser's `--auto-snapshot`.

Additionally, `goreleaser build` doesn't actually build the Linux packages, so it wasn't very useful in the first place.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
