### PR TITLE
Disable parent keepalived check and oom score adjustment in test mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,9 +85,11 @@ func main() {
 
 	setupLogger()
 
-	WaitForKeepalivedTermination(ctx, stop)
-	if err = configOutOfMemoryKiller(); err != nil {
-		log.Fatal(err)
+	if !testMode {
+		WaitForKeepalivedTermination(ctx, stop)
+		if err = configOutOfMemoryKiller(); err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	configFile := flag.Arg(0)


### PR DESCRIPTION
## Summary

We don't need to check for a keepalived parent process or adjust our own OOM score when running the self-test. This change should allow running the Floaty self-test as a non-root user as long as that user can access the Floaty config file.

Extracted from #92 

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update the documentation.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
