### PR TITLE
Revert broken Renovate `cenkalti/backoff/v5` update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ toolchain go1.25.1
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0
-	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cloudscale-ch/cloudscale-go-sdk/v5 v5.1.0
 	github.com/exoscale/egoscale/v3 v3.1.26
 	github.com/fsnotify/fsnotify v1.9.0
@@ -20,6 +19,7 @@ require (
 )
 
 require (
+	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/diskfs/go-diskfs v1.4.0 // indirect
 	github.com/elliotwutingfeng/asciiset v0.0.0-20230602022725-51bbb787efab // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
-github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
-github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
+github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
+github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cloudscale-ch/cloudscale-go-sdk/v5 v5.1.0 h1:5JfDWIPR7vZPynkQHi042P5F+dwq6Vk28TkoPj6U+ts=
 github.com/cloudscale-ch/cloudscale-go-sdk/v5 v5.1.0/go.mod h1:diuqAehpkhH5p9ACknlgw7+HQtHuZI7ZRy+JNXQaOW8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
We'll need to properly look at updating to `cenkalti/backoff/v5` at some point, but there's quite a lot of changes between v4 and v5 and we use the package in quite a few places in floaty.

Reverts #105 

## Summary



## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
